### PR TITLE
tests: match expected code

### DIFF
--- a/util/assigment-tests.py
+++ b/util/assigment-tests.py
@@ -2,118 +2,124 @@ from subprocess import check_call, PIPE, Popen
 from os import chdir
 from sys import argv
 from pathlib import Path
-from typing import List, Tuple, NamedTuple
+from typing import List, Tuple, NamedTuple, Optional
 
 
 class TestCase(NamedTuple):
     args: List[str]
     data_in: bytes
-    expected_out: bytes
-
+    expected_out: Optional[bytes]
+    expected_code: int
 
 
 TESTS: List[TestCase] = [
     # bytes
-    TestCase(args=['-f', 'bytes', '-t', 'bytes'], data_in=b'test', expected_out=b'test'),
-    TestCase(args=['-f', 'bytes', '-t', 'bytes'], data_in='čauky'.encode('utf8'), expected_out='čauky'.encode('utf8')),  # extended test
-    TestCase(args=['-f', 'bytes', '-t', 'bytes'], data_in=b'test1\ntest2', expected_out=b'test1\ntest2'),  # extended test
+    TestCase(args=['-f', 'bytes', '-t', 'bytes'], data_in=b'test', expected_out=b'test', expected_code=0),
+    TestCase(args=['-f', 'bytes', '-t', 'bytes'], data_in='čauky'.encode('utf8'), expected_out='čauky'.encode('utf8'), expected_code=0),  # extended test
+    TestCase(args=['-f', 'bytes', '-t', 'bytes'], data_in=b'test1\ntest2', expected_out=b'test1\ntest2', expected_code=0),  # extended test
     # hex
-    TestCase(args=['-f', 'hex', '-t', 'bytes'], data_in=b'74657374', expected_out=b'test'),
-    TestCase(args=['-f', 'bytes', '-t', 'hex'], data_in=b'test', expected_out=b'74657374'),
-    TestCase(args=['-f', 'hex', '-t', 'bytes'], data_in=b'74 65 73 74', expected_out=b'test'),
+    TestCase(args=['-f', 'hex', '-t', 'bytes'], data_in=b'74657374', expected_out=b'test', expected_code=0),
+    TestCase(args=['-f', 'bytes', '-t', 'hex'], data_in=b'test', expected_out=b'74657374', expected_code=0),
+    TestCase(args=['-f', 'hex', '-t', 'bytes'], data_in=b'74 65 73 74', expected_out=b'test', expected_code=0),
     # int
-    TestCase(args=['-f', 'int', '-t', 'hex'], data_in=b'1234567890', expected_out=b'499602d2'),
-    TestCase(args=['-f', 'int', '-t', 'hex', '--from-options=big'], data_in=b'1234567890', expected_out=b'499602d2'),
-    TestCase(args=['-f', 'int', '-t', 'hex', '--from-options=little'], data_in=b'1234567890', expected_out=b'd2029649'),
-    TestCase(args=['-f', 'hex', '-t', 'int'], data_in=b'499602d2', expected_out=b'1234567890'),
-    TestCase(args=['-f', 'hex', '-t', 'int', '--to-options=big'], data_in=b'499602d2', expected_out=b'1234567890'),
-    TestCase(args=['-f', 'hex', '-t', 'int', '--to-options=little'], data_in=b'd2029649', expected_out=b'1234567890'),
+    TestCase(args=['-f', 'int', '-t', 'hex'], data_in=b'1234567890', expected_out=b'499602d2', expected_code=0),
+    TestCase(args=['-f', 'int', '-t', 'hex', '--from-options=big'], data_in=b'1234567890', expected_out=b'499602d2', expected_code=0),
+    TestCase(args=['-f', 'int', '-t', 'hex', '--from-options=little'], data_in=b'1234567890', expected_out=b'd2029649', expected_code=0),
+    TestCase(args=['-f', 'hex', '-t', 'int'], data_in=b'499602d2', expected_out=b'1234567890', expected_code=0),
+    TestCase(args=['-f', 'hex', '-t', 'int', '--to-options=big'], data_in=b'499602d2', expected_out=b'1234567890', expected_code=0),
+    TestCase(args=['-f', 'hex', '-t', 'int', '--to-options=little'], data_in=b'd2029649', expected_out=b'1234567890', expected_code=0),
     # bits
-    TestCase(args=['-f', 'bits', '-t', 'bytes'], data_in=b'100 1111 0100 1011', expected_out=b'OK'),
-    TestCase(args=['-f', 'bits', '-t', 'bytes', '--from-options=left'], data_in=b'100111101001011', expected_out=b'OK'),
-    TestCase(args=['-f', 'bits', '-t', 'hex', '--from-options=right'], data_in=b'100111101001011', expected_out=b'9e96'),
-    TestCase(args=['-f', 'bytes', '-t', 'bits'], data_in=b'OK', expected_out=b'0100111101001011'),
+    TestCase(args=['-f', 'bits', '-t', 'bytes'], data_in=b'100 1111 0100 1011', expected_out=b'OK', expected_code=0),
+    TestCase(args=['-f', 'bits', '-t', 'bytes', '--from-options=left'], data_in=b'100111101001011', expected_out=b'OK', expected_code=0),
+    TestCase(args=['-f', 'bits', '-t', 'hex', '--from-options=right'], data_in=b'100111101001011', expected_out=b'9e96', expected_code=0),
+    TestCase(args=['-f', 'bytes', '-t', 'bits'], data_in=b'OK', expected_out=b'0100111101001011', expected_code=0),
     # array
     TestCase(
         args=['-f', 'hex', '-t', 'array'],
         data_in=b'01020304',
         expected_out=b'{0x1, 0x2, 0x3, 0x4}'
-    ),
+    , expected_code=0),
     TestCase(
         args=['-f', 'array', '-t', 'hex'],
         data_in=br"{0x01, 2, 0b11, '\x04'}",
         expected_out=b'01020304'
-    ),
+    , expected_code=0),
     TestCase(
         args=['-f', 'array', '-t', 'hex'],
         data_in=br"((1, 2), (3, 4))",
         expected_out=b'01020304'
-    ),
+    , expected_code=0),
     TestCase(
         args=['-f', 'array', '-t', 'hex'],
         data_in=br"{0x01, 0x02}",
         expected_out=b'0102'
-    ),
+    , expected_code=0),
     TestCase(
         args=['-f', 'array', '-t', 'array'],
         data_in=br"{0x01,2,0b11 ,'\x04' }",
         expected_out=b'{0x1, 0x2, 0x3, 0x4}'
-    ),
+    , expected_code=0),
     TestCase(
         args=['-f', 'array', '-t', 'array', '--to-options=0x'],
         data_in=br"[0x01, 2, 0b11, '\x04']",
         expected_out=b'{0x1, 0x2, 0x3, 0x4}'
-    ),
+    , expected_code=0),
     TestCase(
         args=['-f', 'array', '-t', 'array', '--to-options=0'],
         data_in=br"(0x01, 2, 0b11, '\x04')",
         expected_out=b'{1, 2, 3, 4}'
-    ),
+    , expected_code=0),
     TestCase(
         args=['-f', 'array', '-t', 'array', '--to-options=a'],
         data_in=br"{0x01, 2, 0b11, '\x04'}",
         expected_out=br"{'\x01', '\x02', '\x03', '\x04'}"
-    ),
+    , expected_code=0),
     TestCase(
         args=['-f', 'array', '-t', 'array', '--to-options=0b'],
         data_in=br"[0x01, 2, 0b11, '\x04']",
         expected_out=br"{0b1, 0b10, 0b11, 0b100}"
-    ),
+    , expected_code=0),
     TestCase(
         args=['-f', 'array', '-t', 'array', '--to-options="("'],
         data_in=br"(0x01, 2, 0b11, '\x04')",
         expected_out=br"(0x1, 0x2, 0x3, 0x4)"
-    ),
+    , expected_code=0),
     TestCase(
         args=['-f', 'array', '-t', 'array', '--to-options=0', '--to-options="["'],
         data_in=br"{0x01, 2, 0b11, '\x04'}",
         expected_out=br"[1, 2, 3, 4]"
-    ),
+    , expected_code=0),
     TestCase(
         args=['-f', 'array', '-t', 'array'],
         data_in=br"[[1, 2], [3, 4], [5, 6]]",
         expected_out=br"{{0x1, 0x2}, {0x3, 0x4}, {0x5, 0x6}}"
-    ),
+    , expected_code=0),
     TestCase(
         args=['-f', 'array', '-t', 'array', '--to-options="{"', '--to-options=0'],
         data_in=br"[[1, 2], [3, 4], [5, 6]]",
         expected_out=br"{{1, 2}, {3, 4}, {5, 6}}"
-    ),
+    , expected_code=0),
     TestCase(
         args=['-f', 'array', '-t', 'array', '--to-options=0', '--to-options="["'],
         data_in=br"{{0x01, (2), [3, 0b100, 0x05], '\x06'}}",
         expected_out=br"[[1, [2], [3, 4, 5], 6]]"
-    ),
+    , expected_code=0),
     TestCase(
         args=['-f', 'array', '-t', 'array'],
         data_in=br"()",
         expected_out=br"{}"
-    ),
+    , expected_code=0),
     TestCase(
         args=['-f', 'array', '-t', 'array', '--to-options="["'],
         data_in=br"([],{})",
         expected_out=br"[[], []]"
-    ),
+    , expected_code=0),
+    TestCase(
+        args=['-f', 'array', '-t', 'hex'],
+        data_in=br"(",
+        expected_out=None,
+        expected_code=1
+    )
 ]
 
 
@@ -142,7 +148,7 @@ def build_jar(force_refresh: bool = False) -> Path:
     return path_jar
 
 
-def execute_single_test(path_jar: Path, args: List[str], data_in: bytes) -> Tuple[bytes, bytes]:
+def execute_single_test(path_jar: Path, args: List[str], data_in: bytes) -> Tuple[bytes, bytes, int]:
     """
     Executes a single test scenario
     :param path_jar: path to the jar file
@@ -154,7 +160,7 @@ def execute_single_test(path_jar: Path, args: List[str], data_in: bytes) -> Tupl
     process = Popen(command, stdin=PIPE, stdout=PIPE, stderr=PIPE)
     stdout, stderr = process.communicate(input=data_in, timeout=300)
 
-    return stdout, stderr
+    return stdout, stderr, process.returncode
 
 
 def main() -> int:
@@ -172,13 +178,13 @@ def main() -> int:
 
     for i, case in enumerate(TESTS):
         print(f'TEST {i+1}/{len(TESTS)} ... ', end='', flush=True)
-        stdout, stderr = execute_single_test(path_jar, case.args, case.data_in)
-        if stdout == case.expected_out:
+        stdout, stderr, return_code = execute_single_test(path_jar, case.args, case.data_in)
+        if (case.expected_out is None or stdout == case.expected_out) and return_code == case.expected_code:
             count_passed += 1
             print('OK')
         else:
-            print('FAIL!')
-            print(f'- expected: {case.expected_out}')
+            print(f'FAIL! (exited with {return_code}, in={case.data_in}, args={case.args})')
+            print(f'- expected: {case.expected_out} ({case.expected_code})')
             print(f'- received: {stdout}')
             if stderr:
                 print(f'- stderr:   {stderr}')


### PR DESCRIPTION
-  `expected_out` can be `None` if it does not matter
- `expected_code` must be specified