### PR TITLE
Fix edge case behavior for byte array input/output

### DIFF
--- a/src/main/java/cz/muni/fi/pv286/parser/input/PanbyteArrayInput.java
+++ b/src/main/java/cz/muni/fi/pv286/parser/input/PanbyteArrayInput.java
@@ -90,6 +90,9 @@ public class PanbyteArrayInput extends PanbyteInputBase {
                                 throw new IllegalArgumentException("Parsing array error: Invalid bracket sequence");
                             }
                             this.state = ParseStatus.SEEK_INPUT_END;
+                            // Edge case: Empty bytearray, should be outputted as nested element explicitly
+                            if (this.output.getClass() == PanbyteArrayOutput.class)
+                                this.output.stringify(null);
                         } else {
                             // allow closing this newly opened bracket
                             this.state = ParseStatus.SEEK_INPUT_START;

--- a/src/main/java/cz/muni/fi/pv286/parser/input/PanbyteIntInput.java
+++ b/src/main/java/cz/muni/fi/pv286/parser/input/PanbyteIntInput.java
@@ -7,6 +7,7 @@ import cz.muni.fi.pv286.parser.output.PanbyteOutput;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -60,6 +61,13 @@ public class PanbyteIntInput extends PanbyteInputBase {
         // this method could be called with no bytes parsed
         if (this.integer != null) {
             byte[] integerByteArray = this.integer.toByteArray();
+
+            // Skip leading zero bytes, inserted due to java byte and BigInteger's two's complement representation
+            int leadingZeroBytesCursor = 0;
+            while (integerByteArray[leadingZeroBytesCursor] == 0 && leadingZeroBytesCursor < integerByteArray.length - 1)
+                leadingZeroBytesCursor++;
+
+            integerByteArray = Arrays.copyOfRange(integerByteArray, leadingZeroBytesCursor, integerByteArray.length);
 
             for (byte b : integerByteArray) {
                 this.parsedBytes.add(b);

--- a/src/test/java/cz/muni/fi/pv286/parser/PanbyteArrayOutputTest.java
+++ b/src/test/java/cz/muni/fi/pv286/parser/PanbyteArrayOutputTest.java
@@ -650,4 +650,62 @@ public class PanbyteArrayOutputTest {
             assert(true);
         }
     }
+
+    @Test
+    void inputSingleValueArray_outputSingleValueArray() {
+        String inputString = "{128}";
+        final OutputStream stdoutWriter = new java.io.ByteArrayOutputStream();
+        final InputStream stdinReader = new java.io.ByteArrayInputStream(inputString.getBytes(StandardCharsets.US_ASCII));
+
+        final PanbyteOutput output = new PanbyteArrayOutput(stdoutWriter, Option.HEX, Option.CURLY_BRACKETS);
+        final PanbyteInput input = new PanbyteArrayInput(output);
+
+        try {
+            processIO(stdinReader, stdoutWriter, input, "\n".getBytes(StandardCharsets.US_ASCII));
+        } catch (Exception e) {
+            assert(false);
+        }
+
+        String result = stdoutWriter.toString();
+        assert(result.equals("{0x80}"));
+    }
+
+    @Test
+    void inputTwoElemNestedArray_outputTwoElemNestedArray() {
+        String inputString = "{{}, 1}";
+        final OutputStream stdoutWriter = new java.io.ByteArrayOutputStream();
+        final InputStream stdinReader = new java.io.ByteArrayInputStream(inputString.getBytes(StandardCharsets.US_ASCII));
+
+        final PanbyteOutput output = new PanbyteArrayOutput(stdoutWriter, Option.HEX, Option.CURLY_BRACKETS);
+        final PanbyteInput input = new PanbyteArrayInput(output);
+
+        try {
+            processIO(stdinReader, stdoutWriter, input, "\n".getBytes(StandardCharsets.US_ASCII));
+        } catch (Exception e) {
+            assert(false);
+        }
+
+        String result = stdoutWriter.toString();
+        assert(result.equals("{{}, 0x1}"));
+    }
+
+
+    @Test
+    void inputThreeElemNestedArray_outputThreeElemNestedArray() {
+        String inputString = "{128, {}, 128}";
+        final OutputStream stdoutWriter = new java.io.ByteArrayOutputStream();
+        final InputStream stdinReader = new java.io.ByteArrayInputStream(inputString.getBytes(StandardCharsets.US_ASCII));
+
+        final PanbyteOutput output = new PanbyteArrayOutput(stdoutWriter, Option.HEX, Option.CURLY_BRACKETS);
+        final PanbyteInput input = new PanbyteArrayInput(output);
+
+        try {
+            processIO(stdinReader, stdoutWriter, input, "\n".getBytes(StandardCharsets.US_ASCII));
+        } catch (Exception e) {
+            assert(false);
+        }
+
+        String result = stdoutWriter.toString();
+        assert(result.equals("{0x80, {}, 0x80}"));
+    }
 }

--- a/src/test/java/cz/muni/fi/pv286/parser/PanbyteArrayOutputTest.java
+++ b/src/test/java/cz/muni/fi/pv286/parser/PanbyteArrayOutputTest.java
@@ -671,6 +671,24 @@ public class PanbyteArrayOutputTest {
     }
 
     @Test
+    void inputTwoElemNestedArray_outputTwoElemNestedArrayNumberFirst() {
+        String inputString = "{1, {}}";
+        final OutputStream stdoutWriter = new java.io.ByteArrayOutputStream();
+        final InputStream stdinReader = new java.io.ByteArrayInputStream(inputString.getBytes(StandardCharsets.US_ASCII));
+
+        final PanbyteOutput output = new PanbyteArrayOutput(stdoutWriter, Option.HEX, Option.CURLY_BRACKETS);
+        final PanbyteInput input = new PanbyteArrayInput(output);
+
+        try {
+            processIO(stdinReader, stdoutWriter, input, "\n".getBytes(StandardCharsets.US_ASCII));
+        } catch (Exception e) {
+            assert(false);
+        }
+
+        String result = stdoutWriter.toString();
+        assert(result.equals("{0x1, {}}"));
+    }
+    @Test
     void inputTwoElemNestedArray_outputTwoElemNestedArray() {
         String inputString = "{{}, 1}";
         final OutputStream stdoutWriter = new java.io.ByteArrayOutputStream();
@@ -689,6 +707,24 @@ public class PanbyteArrayOutputTest {
         assert(result.equals("{{}, 0x1}"));
     }
 
+    @Test
+    void inputTwoElemDoubleNestedArray_outputTwoElemDoubleNestedArray() {
+        String inputString = "{{{}}, 1}";
+        final OutputStream stdoutWriter = new java.io.ByteArrayOutputStream();
+        final InputStream stdinReader = new java.io.ByteArrayInputStream(inputString.getBytes(StandardCharsets.US_ASCII));
+
+        final PanbyteOutput output = new PanbyteArrayOutput(stdoutWriter, Option.HEX, Option.CURLY_BRACKETS);
+        final PanbyteInput input = new PanbyteArrayInput(output);
+
+        try {
+            processIO(stdinReader, stdoutWriter, input, "\n".getBytes(StandardCharsets.US_ASCII));
+        } catch (Exception e) {
+            assert(false);
+        }
+
+        String result = stdoutWriter.toString();
+        assert(result.equals("{{{}}, 0x1}"));
+    }
 
     @Test
     void inputThreeElemNestedArray_outputThreeElemNestedArray() {


### PR DESCRIPTION
This PR fixes the following bugs about application behavior encountered when processing byte arrays.

*Steps to reproduce:*
```bash
echo -ne '{{}, 1}' | java -jar target/panbyte-1.0-SNAPSHOT.jar -f array -t array
echo -ne '{1, {}, 1}' |  java -jar target/panbyte-1.0-SNAPSHOT.jar -f array -t array
echo -ne '{128}' | java -jar target/panbyte-1.0-SNAPSHOT.jar -f array -t array
```

*Expected output:*
```
{{}, 0x1}
{0x1, {}, 0x1}
{0x80}
```

*Actual output:*
```
}{{0x1}
{0x1}, {0x1}
{0x0, 0x80}
```